### PR TITLE
fix for #7: add a stop() method to stop the polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ speech.on('speaking', function() {
 * The hark object also has the following methods to update the config of hark. Both of these options can be passed in on instantiation, but you may wish to alter them either for debug or fine tuning as your app runs.
   * `setInterval(interval_in_ms)` change 
   * `setThreshold(threshold_in_db)` change the minimum volume at which the audio will emit a `speaking` event
+* hark can be stopped by calling this method
+  * `stop()` will stop the polling and events will not be emitted.
 
 ## Options
 

--- a/hark.bundle.js
+++ b/hark.bundle.js
@@ -30,7 +30,8 @@ module.exports = function(stream, options) {
       smoothing = (options.smoothing || 0.5),
       interval = (options.interval || 100),
       threshold = options.threshold,
-      play = options.play;
+      play = options.play,
+      running = true;
 
   //Setup Audio Context
   if (!audioContext) {
@@ -67,11 +68,21 @@ module.exports = function(stream, options) {
   harker.setInterval = function(i) {
     interval = i;
   };
+  
+  harker.stop = function() {
+	  running = false;
+  };
 
   // Poll the analyser node to determine if speaking
   // and emit events if changed
   var looper = function() {
     setTimeout(function() {
+      
+      //check if stop has been called
+      if(!running) {
+        return;
+      }
+      
       var currentVolume = getMaxVolume(analyser, fftBins);
 
       harker.emit('volume_change', currentVolume, threshold);

--- a/hark.js
+++ b/hark.js
@@ -29,7 +29,8 @@ module.exports = function(stream, options) {
       smoothing = (options.smoothing || 0.5),
       interval = (options.interval || 100),
       threshold = options.threshold,
-      play = options.play;
+      play = options.play,
+      running = true;
 
   //Setup Audio Context
   if (!audioContext) {
@@ -66,11 +67,21 @@ module.exports = function(stream, options) {
   harker.setInterval = function(i) {
     interval = i;
   };
+  
+  harker.stop = function() {
+	  running = false;
+  };
 
   // Poll the analyser node to determine if speaking
   // and emit events if changed
   var looper = function() {
     setTimeout(function() {
+    
+      //check if stop has been called
+      if(!running) {
+        return;
+      }
+      
       var currentVolume = getMaxVolume(analyser, fftBins);
 
       harker.emit('volume_change', currentVolume, threshold);


### PR DESCRIPTION
This should allow the application to stop hark from indefinitely polling
the audio stream for volume changes.
