### PR TITLE
Check if window is defined

### DIFF
--- a/hark.js
+++ b/hark.js
@@ -14,7 +14,10 @@ function getMaxVolume (analyser, fftBins) {
 }
 
 
-var audioContextType = window.AudioContext || window.webkitAudioContext;
+var audioContextType;
+if (typeof window !== 'undefined') {
+  audioContextType = window.AudioContext || window.webkitAudioContext;
+}
 // use a single audio context due to hardware limits
 var audioContext = null;
 module.exports = function(stream, options) {


### PR DESCRIPTION
allows importing in a node environment

This lets me run tests on my code that imports hark; it refuses to compile in the node environment otherwise.

Let me know if this is OK or if I could improve the commit, I'm happy to do any leg work
