### PR TITLE
add option to use an existing AudioContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ speech.on('speaking', function() {
   * `stopped_speaking` emitted when the audio doesn't seem to be speaking
   * `volume_change` emitted on every poll event by the event emitter with the current volume (in decibels) and the current threshold for speech
 * The hark object also has the following methods to update the config of hark. Both of these options can be passed in on instantiation, but you may wish to alter them either for debug or fine tuning as your app runs.
-  * `setInterval(interval_in_ms)` change 
+  * `setInterval(interval_in_ms)` change
   * `setThreshold(threshold_in_db)` change the minimum volume at which the audio will emit a `speaking` event
 * hark can be stopped by calling this method
   * `stop()` will stop the polling and events will not be emitted.
@@ -68,6 +68,7 @@ speech.on('speaking', function() {
 * `interval` (optional, default 100ms) how frequently the analyser polls the audio stream to check if speaking has started or stopped. This will also be the frequency of the `volume_change` events.
 * `threshold` (optional, default -50db)  the volume at which `speaking`/`stopped\_speaking` events will be fired
 * `play` (optional, default true for audio tags, false for webrtc streams) whether the audio stream should also be piped to the speakers, or just swallowed by the analyser. Typically for audio tags you would want to hear them, but for microphone based webrtc streams you may not to avoid feedback.
+* `audioContext` (optional, default is to create a new context) If you have already created an `AudioContext`, you can pass it to hark to avoid unnecessarily creating more than one.
 
 ## Understanding dB/volume threshold
 
@@ -82,7 +83,7 @@ Clone and open example/index.html or [view it online](https://otalk.github.io/ha
 
 
 ## Requirements:
- 
+
 * Chrome 27+, remote streams require Chrome 49+
 * Firefox
 * Microsoft Edge, support for remote streams is under consideration

--- a/example/demo.bundle.js
+++ b/example/demo.bundle.js
@@ -126,7 +126,7 @@ for (var i = 0; i < 100; i++) {
   window.requestAnimationFrame(draw);
 })();
 
-},{"../hark.js":2,"attachmediastream":5,"bows":3,"getusermedia":4}],4:[function(require,module,exports){
+},{"../hark.js":2,"attachmediastream":4,"bows":5,"getusermedia":3}],3:[function(require,module,exports){
 // getUserMedia helper by @HenrikJoreteg
 var func = (navigator.getUserMedia ||
             navigator.webkitGetUserMedia ||
@@ -161,7 +161,7 @@ module.exports = function (constraints, cb) {
     });
 };
 
-},{}],5:[function(require,module,exports){
+},{}],4:[function(require,module,exports){
 module.exports = function (stream, el, options) {
     var URL = window.URL;
     var opts = {
@@ -219,7 +219,10 @@ function getMaxVolume (analyser, fftBins) {
 }
 
 
-var audioContextType = window.AudioContext || window.webkitAudioContext;
+var audioContextType;
+if (typeof window !== 'undefined') {
+  audioContextType = window.AudioContext || window.webkitAudioContext;
+}
 // use a single audio context due to hardware limits
 var audioContext = null;
 module.exports = function(stream, options) {
@@ -236,6 +239,7 @@ module.exports = function(stream, options) {
       threshold = options.threshold,
       play = options.play,
       history = options.history || 10,
+      audioContext = options.audioContext || null,
       running = true;
 
   //Setup Audio Context
@@ -247,7 +251,7 @@ module.exports = function(stream, options) {
   analyser = audioContext.createAnalyser();
   analyser.fftSize = 512;
   analyser.smoothingTimeConstant = smoothing;
-  fftBins = new Float32Array(analyser.fftSize);
+  fftBins = new Float32Array(analyser.frequencyBinCount);
 
   if (stream.jquery) stream = stream[0];
   if (stream instanceof HTMLAudioElement || stream instanceof HTMLVideoElement) {
@@ -489,7 +493,7 @@ WildEmitter.mixin = function (constructor) {
 
 WildEmitter.mixin(WildEmitter);
 
-},{}],3:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 (function(window) {
   var logger = require('andlog'),
       goldenRatio = 0.618033988749895,

--- a/hark.bundle.js
+++ b/hark.bundle.js
@@ -16,7 +16,10 @@ function getMaxVolume (analyser, fftBins) {
 }
 
 
-var audioContextType = window.AudioContext || window.webkitAudioContext;
+var audioContextType;
+if (typeof window !== 'undefined') {
+  audioContextType = window.AudioContext || window.webkitAudioContext;
+}
 // use a single audio context due to hardware limits
 var audioContext = null;
 module.exports = function(stream, options) {
@@ -33,6 +36,7 @@ module.exports = function(stream, options) {
       threshold = options.threshold,
       play = options.play,
       history = options.history || 10,
+      audioContext = options.audioContext || null,
       running = true;
 
   //Setup Audio Context
@@ -44,7 +48,7 @@ module.exports = function(stream, options) {
   analyser = audioContext.createAnalyser();
   analyser.fftSize = 512;
   analyser.smoothingTimeConstant = smoothing;
-  fftBins = new Float32Array(analyser.fftSize);
+  fftBins = new Float32Array(analyser.frequencyBinCount);
 
   if (stream.jquery) stream = stream[0];
   if (stream instanceof HTMLAudioElement || stream instanceof HTMLVideoElement) {

--- a/hark.js
+++ b/hark.js
@@ -34,6 +34,7 @@ module.exports = function(stream, options) {
       threshold = options.threshold,
       play = options.play,
       history = options.history || 10,
+      audioContext = options.audioContext || null,
       running = true;
 
   //Setup Audio Context


### PR DESCRIPTION
Since Hark creates an audio context each time it is initialized, it is
not a good option to monitor audio levels or speech events in situations
where there are multiple streams that require it. Only a single
`AudioContext` is required per `document`, so it would be advantageous to
allow passing an existing one to Hark, if required.