### PR TITLE
State management for underlying AudioContext object

### DIFF
--- a/hark.js
+++ b/hark.js
@@ -64,6 +64,19 @@ module.exports = function(stream, options) {
 
   harker.speaking = false;
 
+  harker.suspend = function() {
+    audioContext.suspend();
+  }
+  harker.resume = function() {
+    audioContext.resume();
+  }
+  Object.defineProperty(harker, 'state', { get: function() {
+    return audioContext.state;
+  }});
+  audioContext.onstatechange = function() {
+    harker.emit('state_change', audioContext.state);
+  }
+
   harker.setThreshold = function(t) {
     threshold = t;
   };


### PR DESCRIPTION
This allows the AudioContext object created by hark to be managed
by a user of the library. In particular, useful for iOS WebRTC scenarios
where the AudioContext stream must be started by a user action.

See https://bugs.webkit.org/show_bug.cgi?id=177292 for more info. Hopefully they'll remove this silly restriction for the WebRTC case in the future, but for now, it will make hark work for iOS.

Not sure if the API is what you want, let me know if you'd like it structured differently -- I just went with what the person in that thread gave me as a starting point.